### PR TITLE
Do not reset the button state when the menu opens.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -164,7 +164,6 @@ const Extension = new Lang.Class({
             function(menu, open) {
                 if (!open)
                     return;
-                this._hibernateAction.visible = true;
                 this._updateHaveHibernate();
                 this._updateHaveHybridSleep();
             }));


### PR DESCRIPTION
Before this patch, if you have hibernate disabled, the hibernate button
shows up transiently whenever you open the system menu, only to disappear
very quickly.
This patch prevents the button dance, but still allows the button to appear
or disappear if the hibernate status has changed (the state is changed
by the callback and the button shows up or hides when the callback
completes).