### PR TITLE
add i18n support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 **/*.compiled
 *.zip
+.~
+*~
+*.mo
+po/hibernate-status-button.pot

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,94 @@
+# Basic Makefile
+
+UUID = hibernate-status@dromi
+BASE_MODULES = extension.js metadata.json confirmDialog.js LICENSE README.md
+EXTRA_MODULES = prefs.js
+TOLOCALIZE =  confirmDialog.js
+MSGSRC = $(wildcard po/*.po)
+ifeq ($(strip $(DESTDIR)),)
+	INSTALLTYPE = local
+	INSTALLBASE = $(HOME)/.local/share/gnome-shell/extensions
+else
+	INSTALLTYPE = system
+	SHARE_PREFIX = $(DESTDIR)/usr/share
+	INSTALLBASE = $(SHARE_PREFIX)/gnome-shell/extensions
+endif
+INSTALLNAME = hibernate-status@dromi
+
+# The command line passed variable VERSION is used to set the version string
+# in the metadata and in the generated zip-file. If no VERSION is passed, the
+# current commit SHA1 is used as version number in the metadata while the
+# generated zip file has no string attached.
+ifdef VERSION
+	VSTRING = _v$(VERSION)
+else
+	VERSION = $(shell git rev-parse HEAD)
+	VSTRING =
+endif
+
+all: extension
+
+clean:
+	rm -f ./schemas/gschemas.compiled
+	rm -f ./po/*~
+	rm -f ./po/*.mo
+	rm -f ./po/hibernate-status-button.pot
+
+extension: ./schemas/gschemas.compiled $(MSGSRC:.po=.mo)
+
+./schemas/gschemas.compiled: ./schemas/org.gnome.shell.extensions.hibernate-status-button.gschema.xml
+	glib-compile-schemas ./schemas/
+
+potfile: ./po/hibernate-status-button.pot
+
+mergepo: potfile
+	for l in $(MSGSRC); do \
+		msgmerge -U $$l ./po/hibernate-status-button.pot; \
+	done;
+
+./po/hibernate-status-button.pot: $(TOLOCALIZE)
+	mkdir -p po
+	xgettext -k --keyword=__ --keyword=N__ --add-comments='Translators:' -o po/hibernate-status-button.pot --package-name "Hibernate Status Button" $(TOLOCALIZE)
+
+./po/%.mo: ./po/%.po
+	msgfmt -c $< -o $@
+
+install: install-local
+
+install-local: _build
+	rm -rf $(INSTALLBASE)/$(INSTALLNAME)
+	mkdir -p $(INSTALLBASE)/$(INSTALLNAME)
+	cp -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
+ifeq ($(INSTALLTYPE),system)
+	# system-wide settings and locale files
+	# rm -r $(INSTALLBASE)/$(INSTALLNAME)/schemas
+	rm -f $(INSTALLBASE)/$(INSTALLNAME)/schemas/*gschema.xml
+	rm -r $(INSTALLBASE)/$(INSTALLNAME)/locale
+	mkdir -p $(SHARE_PREFIX)/glib-2.0/schemas $(SHARE_PREFIX)/locale
+	cp -r ./schemas/*gschema.* $(SHARE_PREFIX)/glib-2.0/schemas
+	cp -r ./_build/locale/* $(SHARE_PREFIX)/locale
+endif
+	-rm -fR _build
+	echo done
+
+zip-file: _build
+	cd _build ; \
+	zip -qr "$(UUID)$(VSTRING).zip" .
+	mv _build/$(UUID)$(VSTRING).zip ./
+	-rm -fR _build
+
+_build: all
+	-rm -fR ./_build
+	mkdir -p _build
+	cp $(BASE_MODULES) $(EXTRA_MODULES) _build
+	mkdir -p _build/schemas
+	cp schemas/*.xml _build/schemas/
+	cp schemas/gschemas.compiled _build/schemas/
+	mkdir -p _build/locale
+	for l in $(MSGSRC:.po=.mo) ; do \
+		lf=_build/locale/`basename $$l .mo`; \
+		mkdir -p $$lf; \
+		mkdir -p $$lf/LC_MESSAGES; \
+		cp $$l $$lf/LC_MESSAGES/hibernate-status-button.mo; \
+	done;
+	sed -i 's/"version": -1/"version": "$(VERSION)"/'  _build/metadata.json;

--- a/confirmDialog.js
+++ b/confirmDialog.js
@@ -13,17 +13,23 @@ const CheckBox = imports.ui.checkBox.CheckBox;
 const St = imports.gi.St;
 const Clutter = imports.gi.Clutter;
 
+// Use __ () and N__() for the extension gettext domain, and reuse
+// the shell domain with the default _() and N_()
+const Gettext = imports.gettext.domain('hibernate-status-button');
+const __ = Gettext.gettext;
+const N__ = function(e) { return e };
+
 var HibernateDialogContent = {
-    subject: C_("title", "Hibernate"),
-    description: "Do you really want to hibernate the system?",
+    subject: C_("title", __("Hibernate")),
+    description: __("Do you really want to hibernate the system?"),
     confirmButtons: [{
         signal: 'Cancel',
-        label: C_("button", "Cancel"),
+        label: C_("button", __("Cancel")),
         key: Clutter.Escape
     },
     {
         signal: 'ConfirmedHibernate',
-        label: C_("button", "Hibernate"),
+        label: C_("button", __("Hibernate")),
         default: true
     }],
     iconName: 'document-save-symbolic',
@@ -31,16 +37,16 @@ var HibernateDialogContent = {
 };
 
 var SystemdMissingDialogContent = {
-    subject: C_("title", "Hybernate button: Systemd Missing"),
-    description: "Systemd seems to be missing and is required.",
+    subject: C_("title", __("Hibernate button: Systemd Missing")),
+    description: __("Systemd seems to be missing and is required."),
     confirmButtons: [{
         signal: 'Cancel',
-        label: C_("button", "Cancel"),
+        label: C_("button", __("Cancel")),
         key: Clutter.Escape
     },
     {
         signal: 'DisableExtension',
-        label: C_("button", "Disable Extension"),
+        label: C_("button", __("Disable Extension")),
         default: true
     }],
     iconName: 'document-save-symbolic',
@@ -49,21 +55,21 @@ var SystemdMissingDialogContent = {
 
 
 var HibernateFailedDialogContent = {
-    subject: C_("title", "Hybernate button: Hibernate failed"),
-    description: "Looks like hibernation failed.\n" +
+    subject: C_("title", __("Hibernate button: Hibernate failed")),
+    description: __("Looks like hibernation failed.\n" +
         "On some linux distributions hibernation is disabled\n" +
         "because not all hardware supports it well;\n" +
         "please check your distribution documentation\n" +
-        "on how to enable it.",
-    checkBox: "You are wrong, don't check this anymore!",
+        "on how to enable it."),
+    checkBox: __("You are wrong, don't check this anymore!"),
     confirmButtons: [{
         signal: 'Cancel',
-        label: C_("button", "Cancel"),
+        label: C_("button", __("Cancel")),
         key: Clutter.Escape
     },
     {
         signal: 'DisableExtension',
-        label: C_("button", "Disable Extension"),
+        label: C_("button", __("Disable Extension")),
         default: true
     }],
     iconName: 'document-save-symbolic',

--- a/extension.js
+++ b/extension.js
@@ -3,6 +3,7 @@ const GLib = imports.gi.GLib;
 const Lang = imports.lang;
 const Mainloop = imports.mainloop;
 
+const ExtensionUtils = imports.misc.extensionUtils;
 const LoginManager = imports.misc.loginManager;
 const Main = imports.ui.main;
 const StatusSystem = imports.ui.status.system;
@@ -235,6 +236,7 @@ class Extension {
 
 let extension;
 function init() {
+    ExtensionUtils.initTranslations('hibernate-status-button');
     extension = new Extension();
 }
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,0 +1,59 @@
+# Simplified Chinese translation of hibernate-status-button
+# Copyright (C) 2019 zhmars
+# This file is distributed under the same license as the hibernate-status-button package.
+# zhmars <1403122061@qq.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Hibernate Status Button\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-11-22 00:08+0800\n"
+"PO-Revision-Date: 2019-11-21 20:00+0800\n"
+"Last-Translator: zhmars <1403122061@qq.com>\n"
+"Language-Team: Chinese (Simplified) <>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: confirmDialog.js:23 confirmDialog.js:32
+msgid "Hibernate"
+msgstr "休眠"
+
+#: confirmDialog.js:24
+msgid "Do you really want to hibernate the system?"
+msgstr "确定要休眠系统吗？"
+
+#: confirmDialog.js:27 confirmDialog.js:44 confirmDialog.js:67
+msgid "Cancel"
+msgstr "取消"
+
+#: confirmDialog.js:40
+msgid "Hibernate button: Systemd Missing"
+msgstr "无法找到 Systemd"
+
+#: confirmDialog.js:41
+msgid "Systemd seems to be missing and is required."
+msgstr "本功能依赖 Systemd，但目前无法找到。"
+
+#: confirmDialog.js:49 confirmDialog.js:72
+msgid "Disable Extension"
+msgstr "禁用扩展"
+
+#: confirmDialog.js:58
+msgid "Hibernate button: Hibernate failed"
+msgstr "休眠失败"
+
+#: confirmDialog.js:59
+msgid ""
+"Looks like hibernation failed.\n"
+"On some linux distributions hibernation is disabled\n"
+"because not all hardware supports it well;\n"
+"please check your distribution documentation\n"
+"on how to enable it."
+msgstr "休眠好像失败了。由于不是所有硬件都对该功能支持良好，"
+"某些发行版默认禁用了休眠，关于如何启用请查阅你所用的发行版文档"
+
+#: confirmDialog.js:64
+msgid "You are wrong, don't check this anymore!"
+msgstr "忽略本项检查"


### PR DESCRIPTION
Hi, I'm trying to add i18n support. The code was modified from [dash-to-dock](https://github.com/micheleg/dash-to-dock), and I'm not sure it is ok to do that.So feel free to close this.

Currently, to get i18n support, you have to install this extension  to system directory (`/usr/share/gnome-shell`) instead of `~/.local/share/gnome-shell`.