### PR TITLE
Add hybrid sleep option toggle and make confirmation dialog optional

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gnome Shell extension that adds a hibernate/hybrid suspend button in Status menu
 
 Originally developed by [@arelange](https://github.com/arelange); now maintained by [@p91paul](https://github.com/p91paul).
 
-Supports GNOME 3.36.
+Supports GNOME 40-42.
 
 ## FAQ
 

--- a/extension.js
+++ b/extension.js
@@ -10,7 +10,7 @@ const PopupMenu = imports.ui.popupMenu;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const ExtensionSystem = imports.ui.extensionSystem;
 const ConfirmDialog = Me.imports.confirmDialog;
-const Prefs = new Me.imports.prefs.Prefs();
+const Prefs = Me.imports.prefs.getInstance();
 
 
 // Use __ () and N__() for the extension gettext domain, and reuse
@@ -71,7 +71,7 @@ class Extension {
     }
 
     _loginManagerCanHybridSleep(asyncCallback) {
-        if (this._loginManager._proxy) {
+        if (Prefs.getHybridSleepOptionEnabled() && this._loginManager._proxy) {
             // systemd path
             this._loginManager._proxy.call("CanHybridSleep",
                 null,
@@ -99,7 +99,7 @@ class Extension {
     }
 
     _loginManagerHybridSleep() {
-        if (this._loginManager._proxy) {
+        if (Prefs.getHybridSleepOptionEnabled() && this._loginManager._proxy) {
             // systemd path
             this._loginManager._proxy.call("HybridSleep",
                 GLib.Variant.new('(b)', [true]),
@@ -189,12 +189,14 @@ class Extension {
         this._hibernateMenuItem = new PopupMenu.PopupMenuItem(__('Hibernate'));
         this._hibernateMenuItemId = this._hibernateMenuItem.connect('activate', () => this._onHibernateClicked());
 
-        this._hybridSleepMenuItem = new PopupMenu.PopupMenuItem(__('Hybrid Sleep'));
-        this._hybridSleepMenuItemId = this._hybridSleepMenuItem.connect('activate', () => this._onHybridSleepClicked());
-
         let afterSuspendPosition = this.systemMenu._sessionSubMenu.menu.numMenuItems - 5;
 
-        this.systemMenu._sessionSubMenu.menu.addMenuItem(this._hybridSleepMenuItem, afterSuspendPosition);
+        if (Prefs.getHybridSleepOptionEnabled()) {
+          this._hybridSleepMenuItem = new PopupMenu.PopupMenuItem(__('Hybrid Sleep'));
+          this._hybridSleepMenuItemId = this._hybridSleepMenuItem.connect('activate', () => this._onHybridSleepClicked());
+          this.systemMenu._sessionSubMenu.menu.addMenuItem(this._hybridSleepMenuItem, afterSuspendPosition);
+        }
+
         this.systemMenu._sessionSubMenu.menu.addMenuItem(this._hibernateMenuItem, afterSuspendPosition);
 
         this._menuOpenStateChangedId = this.systemMenu.menu.connect('open-state-changed',

--- a/locale/nl/LC_MESSAGES/hibernate-status-button.po
+++ b/locale/nl/LC_MESSAGES/hibernate-status-button.po
@@ -1,4 +1,4 @@
-# Polish translation of hibernate-status-button
+# Dutch translation of hibernate-status-button
 # Copyright (C) 2021 tebaranowski
 # This file is distributed under the same license as the hibernate-status-button package.
 # tebaranowski <tomasz.baranowski@int.pl>, 2021.
@@ -7,46 +7,47 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Hibernate Status Button\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-11 18:31+0200\n"
-"PO-Revision-Date: 2021-09-13 17:56+0200\n"
-"Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
+"POT-Creation-Date: 2022-08-14 12:04+0900\n"
+"PO-Revision-Date: 2022-08-14 12:07+0900\n"
+"Last-Translator: Dave Jansen <i.am@davejansen.com>\n"
 "Language-Team: Dutch <vistausss@fastmail.com>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"X-Generator: Poedit 3.0\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 "
+"|| n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.1.1\n"
 
-#: confirmDialog.js:23 confirmDialog.js:32
+#: confirmDialog.js:25 confirmDialog.js:34
 msgid "Hibernate"
 msgstr "Slaapstand"
 
-#: confirmDialog.js:24
+#: confirmDialog.js:26
 msgid "Do you really want to hibernate the system?"
 msgstr "Weet u zeker dat u het systeem in de slaapstand wilt zetten?"
 
-#: confirmDialog.js:27 confirmDialog.js:44 confirmDialog.js:67
+#: confirmDialog.js:29 confirmDialog.js:46 confirmDialog.js:69
 msgid "Cancel"
 msgstr "Annuleren"
 
-#: confirmDialog.js:40
+#: confirmDialog.js:42
 msgid "Hibernate button: Systemd Missing"
 msgstr "Slaapstandknop: Systemd ontbreekt"
 
-#: confirmDialog.js:41
+#: confirmDialog.js:43
 msgid "Systemd seems to be missing and is required."
 msgstr "Systemd is vereist, maar niet aangetroffen."
 
-#: confirmDialog.js:49 confirmDialog.js:72
+#: confirmDialog.js:51 confirmDialog.js:74
 msgid "Disable Extension"
-msgstr "Uitbreiding uitschakelen"
+msgstr "Extensie uitschakelen"
 
-#: confirmDialog.js:58
+#: confirmDialog.js:60
 msgid "Hibernate button: Hibernate failed"
 msgstr "Slaapstandknop: slaapstand mislukt"
 
-#: confirmDialog.js:59
+#: confirmDialog.js:61
 msgid ""
 "Looks like hibernation failed.\n"
 "On some linux distributions hibernation is disabled\n"
@@ -59,10 +60,21 @@ msgstr ""
 "Neem de documentatie van uw distributie door om te\n"
 "zien of u de slaapstand kunt activeren."
 
-#: confirmDialog.js:64
+#: confirmDialog.js:66
 msgid "You are wrong, don't check this anymore!"
 msgstr "Dit klopt niet - negeer deze controle!"
 
-#: prefs.js:99
-msgid "This extension has no settings available"
-msgstr "Deze uitbreiding bevat geen voorkeurenscherm"
+#: prefs.js:62
+msgid "Enable the hybrid suspend option"
+msgstr "Hybride slaapstand optie weergeven"
+
+#: prefs.js:70
+msgid "Enable the hibernate option"
+msgstr "Slaapstand optie weergeven"
+
+#: prefs.js:78
+msgid "Enable the hibernate confirmation dialog"
+msgstr "Hybride slaapstand confirmatie scherm weergeven"
+
+#~ msgid "This extension has no settings available"
+#~ msgstr "Deze uitbreiding bevat geen voorkeurenscherm"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,7 @@
 {
   "uuid": "hibernate-status@dromi",
   "name": "Hibernate Status Button",
+  "version": 34,
   "url": "https://github.com/arelange/gnome-shell-extension-hibernate-status",
   "description": "Adds a Hibernate button in Status menu. Using Alt modifier, you can also select Hybrid Sleep instead.",
   "shell-version": [

--- a/prefs.js
+++ b/prefs.js
@@ -3,166 +3,197 @@ const Gtk = imports.gi.Gtk;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 // Use __() and N__() for the extension gettext domain, and reuse
 // the shell domain with the default _() and N_()
-const Gettext = imports.gettext.domain('hibernate-status-button');
+const Gettext = imports.gettext.domain("hibernate-status-button");
 const __ = Gettext.gettext;
-const N__ = function(e) { return e };
+const N__ = function (e) {
+  return e;
+};
 const ExtensionUtils = imports.misc.extensionUtils;
 
 let _instance = null;
 function getInstance() {
-    if (!_instance) {
-      _instance = new Prefs();
-    }
+  if (!_instance) {
+    _instance = new Prefs();
+  }
 
-    return _instance;
+  return _instance;
 }
 
 var Prefs = class Prefs {
+  /**
+   * Creates a new Settings-object to access the settings of this extension.
+   * @private
+   */
+  constructor() {
+    this._schemaName = "org.gnome.shell.extensions.hibernate-status-button";
+    this.KEY_HIBERNATE_WORKS_CHECK = "hibernate-works-check";
+    this.KEY_HYBRID_SLEEP_ENABLED = "hybridsleep-enabled";
+    this.KEY_HIBERNATE_ENABLED = "hibernate-enabled";
+    this.KEY_HIBERNATE_CONFIRMATION_ENABLED = "hibernate-confirmation-enabled";
 
-    /**
-     * Creates a new Settings-object to access the settings of this extension.
-     * @private
-     */
-    constructor() {
-      this.KEY_HIBERNATE_WORKS_CHECK = "hibernate-works-check";
-      this.KEY_HYBRID_SLEEP_ENABLED = "hybridsleep-enabled";
-      this._schemaName = "org.gnome.shell.extensions.hibernate-status-button";
+    let schemaDir = Me.dir.get_child("schemas").get_path();
+    let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
+      schemaDir,
+      Gio.SettingsSchemaSource.get_default(),
+      false
+    );
+    let schema = schemaSource.lookup(this._schemaName, false);
 
-      let schemaDir = Me.dir.get_child('schemas').get_path();
-      let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
-          schemaDir, Gio.SettingsSchemaSource.get_default(), false
-      );
-      let schema = schemaSource.lookup(this._schemaName, false);
+    // Define the settings store
+    this._setting = new Gio.Settings({
+      settings_schema: schema,
+    });
+  }
 
-      // Define the settings store
-      this._setting = new Gio.Settings({
-          settings_schema: schema
-      });
+  buildPrefsPanel() {
+    // Define the settings window
+    this.frame = new Gtk.Box({
+      orientation: Gtk.Orientation.VERTICAL,
+      "margin-top": 10,
+      "margin-end": 10,
+      "margin-bottom": 10,
+      "margin-start": 10,
+    });
+
+    // Add the suspend enable toggle option
+    this.frame.append(
+      this.addBooleanOptionButton(
+        this.KEY_HYBRID_SLEEP_ENABLED,
+        __("Enable the hybrid suspend option")
+      )
+    );
+
+    // Add the hibernate enable toggle option
+    this.frame.append(
+      this.addBooleanOptionButton(
+        this.KEY_HIBERNATE_ENABLED,
+        __("Enable the hibernate option")
+      )
+    );
+
+    // Add the hibernate confirmation enable toggle option
+    this.frame.append(
+      this.addBooleanOptionButton(
+        this.KEY_HIBERNATE_CONFIRMATION_ENABLED,
+        __("Enable the hibernate confirmation dialog")
+      )
+    );
+
+    return this.frame;
+  }
+
+  /**
+   * Creates and returns a boolean option for the Settings panel
+   * @param key The setting key name as defined i the schema.xml
+   * @param label The name shown to the end-user. Must be wrapped in __() for localization.
+   * @returns Gtk.Box with the hybrid suspend enable toggle UI.
+   */
+  addBooleanOptionButton(key, label) {
+    const hbox = new Gtk.Box({
+      orientation: Gtk.Orientation.HORIZONTAL,
+      margin_top: 5,
+    });
+
+    const switchButtonLabel = new Gtk.Label({
+      label,
+      xalign: 0,
+      hexpand: true,
+    });
+
+    const switchButton = new Gtk.Switch({
+      active: this._setting.get_boolean(key),
+    });
+
+    switchButton.connect("notify::active", (button) => {
+      this._setting.set_boolean(key, button.active);
+    });
+
+    hbox.append(switchButtonLabel);
+    hbox.append(switchButton);
+
+    return hbox;
+  }
+
+  /**
+   * <p>Binds the given 'callback'-function to the "changed"-signal on the given
+   *  key.</p>
+   * <p>The 'callback'-function is passed an argument which holds the new
+   *  value of 'key'. The argument is of type "GLib.Variant". Given that the
+   *  receiver knows the internal type, use one of the get_XX()-methods to get
+   *  it's actual value.</p>
+   * @see http://www.roojs.com/seed/gir-1.2-gtk-3.0/gjs/GLib.Variant.html
+   * @param key the key to watch for changes.
+   * @param callback the callback-function to call.
+   */
+  bindKey(key, callback) {
+    // Validate:
+    if (key === undefined || key === null || typeof key !== "string") {
+      throw TypeError("The 'key' should be a string. Got: '" + key + "'");
     }
-
-    buildPrefsPanel() {
-      // Define the settings window
-      this.frame = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL,
-         'margin-top': 10,
-         'margin-end': 10,
-         'margin-bottom': 10,
-         'margin-start': 10
-      });
-
-      // Add the suspend enable toggle option
-      this.frame.append(this.hybridSuspendEnableToggleOption());
-
-      return this.frame;
+    if (
+      callback === undefined ||
+      callback === null ||
+      typeof callback !== "function"
+    ) {
+      throw TypeError("'callback' needs to be a function. Got: " + callback);
     }
+    // Bind:
+    this._setting.connect("changed::" + key, function (source, key) {
+      callback(source.get_value(key));
+    });
+  }
 
-    /**
-     * Creates and returns the hybrid suspend enable toggle setting
-     *
-     * @returns Gtk.Box with the hybrid suspend enable toggle UI.
-     */
-    hybridSuspendEnableToggleOption() {
-      const hbox = new Gtk.Box({
-        orientation: Gtk.Orientation.HORIZONTAL,
-        margin_top: 5
-      });
+  /**
+   * Get if check for working hibernation is enabled. The user might
+   * choose to disable it if we happen to be wrong.
+   *
+   * @returns bool true if we need to check if hibernation works.
+   */
+  getHibernateWorksCheckEnabled() {
+    return this._setting.get_boolean(this.KEY_HIBERNATE_WORKS_CHECK);
+  }
 
-      const hybridSuspendEnabledLabel = new Gtk.Label({
-        label: "Enable the hybrid suspend option",
-        xalign: 0,
-        hexpand: true
-      });
+  /**
+   * Get if the hybrid sleep option is enabled.
+   *
+   * @returns bool true if we need to display the option.
+   */
+  getHybridSleepOptionEnabled() {
+    return this._setting.get_boolean(this.KEY_HYBRID_SLEEP_ENABLED);
+  }
 
-      const hybridSupendEnabledSwitch = new Gtk.Switch({
-        active: this._setting.get_boolean(this.KEY_HYBRID_SLEEP_ENABLED)
-      });
-
-      hybridSupendEnabledSwitch.connect('notify::active', (button) => {
-        this._setting.set_boolean(this.KEY_HYBRID_SLEEP_ENABLED, button.active);
-      });
-
-      hbox.append(hybridSuspendEnabledLabel);
-      hbox.append(hybridSupendEnabledSwitch);
-
-      return hbox;
+  /**
+   * Set if check for working hibernation is enabled. The user might
+   * choose to disable it if we happen to be wrong.
+   *
+   * @returns bool true if we need to check if hibernation works.
+   */
+  setHibernateWorksCheckEnabled(enabled) {
+    let key = this.KEY_HIBERNATE_WORKS_CHECK;
+    if (this._setting.is_writable(key)) {
+      if (this._setting.set_boolean(key, enabled)) {
+        Gio.Settings.sync();
+      } else {
+        throw this._errorSet(key);
+      }
+    } else {
+      throw this._errorWritable(key);
     }
-
-    /**
-     * <p>Binds the given 'callback'-function to the "changed"-signal on the given
-     *  key.</p>
-     * <p>The 'callback'-function is passed an argument which holds the new
-     *  value of 'key'. The argument is of type "GLib.Variant". Given that the
-     *  receiver knows the internal type, use one of the get_XX()-methods to get
-     *  it's actual value.</p>
-     * @see http://www.roojs.com/seed/gir-1.2-gtk-3.0/gjs/GLib.Variant.html
-     * @param key the key to watch for changes.
-     * @param callback the callback-function to call.
-     */
-    bindKey(key, callback) {
-        // Validate:
-        if (key === undefined || key === null || typeof key !== "string") {
-            throw TypeError("The 'key' should be a string. Got: '" + key + "'");
-        }
-        if (callback === undefined || callback === null || typeof callback !== "function") {
-            throw TypeError("'callback' needs to be a function. Got: " + callback);
-        }
-        // Bind:
-        this._setting.connect("changed::" + key, function (source, key) {
-            callback(source.get_value(key));
-        });
-    }
-
-    /**
-     * Get if check for working hibernation is enabled. The user might
-     * choose to disable it if we happen to be wrong.
-     *
-     * @returns bool true if we need to check if hibernation works.
-     */
-    getHibernateWorksCheckEnabled() {
-        return this._setting.get_boolean(this.KEY_HIBERNATE_WORKS_CHECK);
-    }
-
-    /**
-     * Get if the hybrid sleep option is enabled.
-     *
-     * @returns bool true if we need to display the option.
-     */
-    getHybridSleepOptionEnabled() {
-      return this._setting.get_boolean(this.KEY_HYBRID_SLEEP_ENABLED);
-    }
-
-    /**
-     * Set if check for working hibernation is enabled. The user might
-     * choose to disable it if we happen to be wrong.
-     *
-     * @returns bool true if we need to check if hibernation works.
-     */
-    setHibernateWorksCheckEnabled(enabled) {
-        let key = this.KEY_HIBERNATE_WORKS_CHECK;
-        if (this._setting.is_writable(key)) {
-            if (this._setting.set_boolean(key, enabled)) {
-                Gio.Settings.sync();
-            } else {
-                throw this._errorSet(key);
-            }
-        } else {
-            throw this._errorWritable(key);
-        }
-    }
-    _errorWritable(key) {
-        return "The key '" + key + "' is not writable.";
-    }
-    _errorSet(key) {
-        return "Couldn't set the key '" + key + "'";
-    }
-}
+  }
+  _errorWritable(key) {
+    return "The key '" + key + "' is not writable.";
+  }
+  _errorSet(key) {
+    return "Couldn't set the key '" + key + "'";
+  }
+};
 
 // These "preferences" aren't user accessible so define
 // init() and buildPrefsWidget() to empty functions
 function init() {
-    ExtensionUtils.initTranslations('hibernate-status-button');
+  ExtensionUtils.initTranslations("hibernate-status-button");
 }
 function buildPrefsWidget() {
-    const prefs = getInstance();
-    return prefs.buildPrefsPanel();
+  const prefs = getInstance();
+  return prefs.buildPrefsPanel();
 }
-

--- a/prefs.js
+++ b/prefs.js
@@ -32,6 +32,8 @@ var Prefs = class Prefs {
         this.KEY_HIBERNATE_CONFIRMATION_ENABLED =
             "hibernate-confirmation-enabled";
 
+        this.onSettingsUpdatedCallback = null;
+
         let schemaDir = Me.dir.get_child("schemas").get_path();
         let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
             schemaDir,
@@ -109,6 +111,12 @@ var Prefs = class Prefs {
             this._setting.set_boolean(key, button.active);
         });
 
+        switchButton.connect("notify::changed", (button) => {
+            if (typeof this.onSettingsUpdatedCallback == "function") {
+                this.onSettingsUpdatedCallback(button.key, button.value);
+            }
+        });
+
         hbox.append(switchButtonLabel);
         hbox.append(switchButton);
 
@@ -144,6 +152,12 @@ var Prefs = class Prefs {
         this._setting.connect("changed::" + key, function (source, key) {
             callback(source.get_value(key));
         });
+    }
+
+    setOnSettingsUpdateCallback(callback) {
+        if (typeof callback == "function")
+            this.onSettingsUpdatedCallback = callback;
+        else this.onSettingsUpdatedCallback = null;
     }
 
     /**
@@ -203,9 +217,11 @@ var Prefs = class Prefs {
             throw this._errorWritable(key);
         }
     }
+
     _errorWritable(key) {
         return "The key '" + key + "' is not writable.";
     }
+
     _errorSet(key) {
         return "Couldn't set the key '" + key + "'";
     }

--- a/prefs.js
+++ b/prefs.js
@@ -32,8 +32,6 @@ var Prefs = class Prefs {
         this.KEY_HIBERNATE_CONFIRMATION_ENABLED =
             "hibernate-confirmation-enabled";
 
-        this.onSettingsUpdatedCallback = null;
-
         let schemaDir = Me.dir.get_child("schemas").get_path();
         let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
             schemaDir,
@@ -111,12 +109,6 @@ var Prefs = class Prefs {
             this._setting.set_boolean(key, button.active);
         });
 
-        switchButton.connect("notify::changed", (button) => {
-            if (typeof this.onSettingsUpdatedCallback == "function") {
-                this.onSettingsUpdatedCallback(button.key, button.value);
-            }
-        });
-
         hbox.append(switchButtonLabel);
         hbox.append(switchButton);
 
@@ -152,12 +144,6 @@ var Prefs = class Prefs {
         this._setting.connect("changed::" + key, function (source, key) {
             callback(source.get_value(key));
         });
-    }
-
-    setOnSettingsUpdateCallback(callback) {
-        if (typeof callback == "function")
-            this.onSettingsUpdatedCallback = callback;
-        else this.onSettingsUpdatedCallback = null;
     }
 
     /**

--- a/prefs.js
+++ b/prefs.js
@@ -47,40 +47,56 @@ var Prefs = class Prefs {
     }
 
     buildPrefsPanel() {
-        // Define the settings window
-        this.frame = new Gtk.Box({
-            orientation: Gtk.Orientation.VERTICAL,
-            "margin-top": 10,
-            "margin-end": 10,
-            "margin-bottom": 10,
-            "margin-start": 10,
+        const grid = new Gtk.Grid({
+            column_spacing: 12,
+            row_spacing: 12,
+            column_homogeneous: true,
+            hexpand: true,
+            vexpand: true,
+            margin_start: 14,
+            margin_end: 14,
+            margin_top: 14,
+            margin_bottom: 14,
+            visible: true,
         });
 
         // Add the suspend enable toggle option
-        this.frame.append(
+        grid.attach(
             this.addBooleanOptionButton(
                 this.KEY_HYBRID_SLEEP_ENABLED,
                 __("Enable the hybrid suspend option")
-            )
+            ),
+            0,
+            0,
+            3,
+            1
         );
 
         // Add the hibernate enable toggle option
-        this.frame.append(
+        grid.attach(
             this.addBooleanOptionButton(
                 this.KEY_HIBERNATE_ENABLED,
                 __("Enable the hibernate option")
-            )
+            ),
+            0,
+            1,
+            3,
+            1
         );
 
         // Add the hibernate confirmation enable toggle option
-        this.frame.append(
+        grid.attach(
             this.addBooleanOptionButton(
                 this.KEY_HIBERNATE_CONFIRMATION_ENABLED,
                 __("Enable the hibernate confirmation dialog")
-            )
+            ),
+            0,
+            2,
+            3,
+            1
         );
 
-        return this.frame;
+        return grid;
     }
 
     /**
@@ -93,6 +109,7 @@ var Prefs = class Prefs {
         const hbox = new Gtk.Box({
             orientation: Gtk.Orientation.HORIZONTAL,
             margin_top: 5,
+            margin_bottom: 5,
         });
 
         const switchButtonLabel = new Gtk.Label({

--- a/prefs.js
+++ b/prefs.js
@@ -6,194 +6,217 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Gettext = imports.gettext.domain("hibernate-status-button");
 const __ = Gettext.gettext;
 const N__ = function (e) {
-  return e;
+    return e;
 };
 const ExtensionUtils = imports.misc.extensionUtils;
 
 let _instance = null;
 function getInstance() {
-  if (!_instance) {
-    _instance = new Prefs();
-  }
+    if (!_instance) {
+        _instance = new Prefs();
+    }
 
-  return _instance;
+    return _instance;
 }
 
 var Prefs = class Prefs {
-  /**
-   * Creates a new Settings-object to access the settings of this extension.
-   * @private
-   */
-  constructor() {
-    this._schemaName = "org.gnome.shell.extensions.hibernate-status-button";
-    this.KEY_HIBERNATE_WORKS_CHECK = "hibernate-works-check";
-    this.KEY_HYBRID_SLEEP_ENABLED = "hybridsleep-enabled";
-    this.KEY_HIBERNATE_ENABLED = "hibernate-enabled";
-    this.KEY_HIBERNATE_CONFIRMATION_ENABLED = "hibernate-confirmation-enabled";
+    /**
+     * Creates a new Settings-object to access the settings of this extension.
+     * @private
+     */
+    constructor() {
+        this._schemaName = "org.gnome.shell.extensions.hibernate-status-button";
+        this.KEY_HIBERNATE_WORKS_CHECK = "hibernate-works-check";
+        this.KEY_HYBRID_SLEEP_ENABLED = "hybridsleep-enabled";
+        this.KEY_HIBERNATE_ENABLED = "hibernate-enabled";
+        this.KEY_HIBERNATE_CONFIRMATION_ENABLED =
+            "hibernate-confirmation-enabled";
 
-    let schemaDir = Me.dir.get_child("schemas").get_path();
-    let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
-      schemaDir,
-      Gio.SettingsSchemaSource.get_default(),
-      false
-    );
-    let schema = schemaSource.lookup(this._schemaName, false);
+        let schemaDir = Me.dir.get_child("schemas").get_path();
+        let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
+            schemaDir,
+            Gio.SettingsSchemaSource.get_default(),
+            false
+        );
+        let schema = schemaSource.lookup(this._schemaName, false);
 
-    // Define the settings store
-    this._setting = new Gio.Settings({
-      settings_schema: schema,
-    });
-  }
-
-  buildPrefsPanel() {
-    // Define the settings window
-    this.frame = new Gtk.Box({
-      orientation: Gtk.Orientation.VERTICAL,
-      "margin-top": 10,
-      "margin-end": 10,
-      "margin-bottom": 10,
-      "margin-start": 10,
-    });
-
-    // Add the suspend enable toggle option
-    this.frame.append(
-      this.addBooleanOptionButton(
-        this.KEY_HYBRID_SLEEP_ENABLED,
-        __("Enable the hybrid suspend option")
-      )
-    );
-
-    // Add the hibernate enable toggle option
-    this.frame.append(
-      this.addBooleanOptionButton(
-        this.KEY_HIBERNATE_ENABLED,
-        __("Enable the hibernate option")
-      )
-    );
-
-    // Add the hibernate confirmation enable toggle option
-    this.frame.append(
-      this.addBooleanOptionButton(
-        this.KEY_HIBERNATE_CONFIRMATION_ENABLED,
-        __("Enable the hibernate confirmation dialog")
-      )
-    );
-
-    return this.frame;
-  }
-
-  /**
-   * Creates and returns a boolean option for the Settings panel
-   * @param key The setting key name as defined i the schema.xml
-   * @param label The name shown to the end-user. Must be wrapped in __() for localization.
-   * @returns Gtk.Box with the hybrid suspend enable toggle UI.
-   */
-  addBooleanOptionButton(key, label) {
-    const hbox = new Gtk.Box({
-      orientation: Gtk.Orientation.HORIZONTAL,
-      margin_top: 5,
-    });
-
-    const switchButtonLabel = new Gtk.Label({
-      label,
-      xalign: 0,
-      hexpand: true,
-    });
-
-    const switchButton = new Gtk.Switch({
-      active: this._setting.get_boolean(key),
-    });
-
-    switchButton.connect("notify::active", (button) => {
-      this._setting.set_boolean(key, button.active);
-    });
-
-    hbox.append(switchButtonLabel);
-    hbox.append(switchButton);
-
-    return hbox;
-  }
-
-  /**
-   * <p>Binds the given 'callback'-function to the "changed"-signal on the given
-   *  key.</p>
-   * <p>The 'callback'-function is passed an argument which holds the new
-   *  value of 'key'. The argument is of type "GLib.Variant". Given that the
-   *  receiver knows the internal type, use one of the get_XX()-methods to get
-   *  it's actual value.</p>
-   * @see http://www.roojs.com/seed/gir-1.2-gtk-3.0/gjs/GLib.Variant.html
-   * @param key the key to watch for changes.
-   * @param callback the callback-function to call.
-   */
-  bindKey(key, callback) {
-    // Validate:
-    if (key === undefined || key === null || typeof key !== "string") {
-      throw TypeError("The 'key' should be a string. Got: '" + key + "'");
+        // Define the settings store
+        this._setting = new Gio.Settings({
+            settings_schema: schema,
+        });
     }
-    if (
-      callback === undefined ||
-      callback === null ||
-      typeof callback !== "function"
-    ) {
-      throw TypeError("'callback' needs to be a function. Got: " + callback);
+
+    buildPrefsPanel() {
+        // Define the settings window
+        this.frame = new Gtk.Box({
+            orientation: Gtk.Orientation.VERTICAL,
+            "margin-top": 10,
+            "margin-end": 10,
+            "margin-bottom": 10,
+            "margin-start": 10,
+        });
+
+        // Add the suspend enable toggle option
+        this.frame.append(
+            this.addBooleanOptionButton(
+                this.KEY_HYBRID_SLEEP_ENABLED,
+                __("Enable the hybrid suspend option")
+            )
+        );
+
+        // Add the hibernate enable toggle option
+        this.frame.append(
+            this.addBooleanOptionButton(
+                this.KEY_HIBERNATE_ENABLED,
+                __("Enable the hibernate option")
+            )
+        );
+
+        // Add the hibernate confirmation enable toggle option
+        this.frame.append(
+            this.addBooleanOptionButton(
+                this.KEY_HIBERNATE_CONFIRMATION_ENABLED,
+                __("Enable the hibernate confirmation dialog")
+            )
+        );
+
+        return this.frame;
     }
-    // Bind:
-    this._setting.connect("changed::" + key, function (source, key) {
-      callback(source.get_value(key));
-    });
-  }
 
-  /**
-   * Get if check for working hibernation is enabled. The user might
-   * choose to disable it if we happen to be wrong.
-   *
-   * @returns bool true if we need to check if hibernation works.
-   */
-  getHibernateWorksCheckEnabled() {
-    return this._setting.get_boolean(this.KEY_HIBERNATE_WORKS_CHECK);
-  }
+    /**
+     * Creates and returns a boolean option for the Settings panel
+     * @param key The setting key name as defined i the schema.xml
+     * @param label The name shown to the end-user. Must be wrapped in __() for localization.
+     * @returns Gtk.Box with the hybrid suspend enable toggle UI.
+     */
+    addBooleanOptionButton(key, label) {
+        const hbox = new Gtk.Box({
+            orientation: Gtk.Orientation.HORIZONTAL,
+            margin_top: 5,
+        });
 
-  /**
-   * Get if the hybrid sleep option is enabled.
-   *
-   * @returns bool true if we need to display the option.
-   */
-  getHybridSleepOptionEnabled() {
-    return this._setting.get_boolean(this.KEY_HYBRID_SLEEP_ENABLED);
-  }
+        const switchButtonLabel = new Gtk.Label({
+            label,
+            xalign: 0,
+            hexpand: true,
+        });
 
-  /**
-   * Set if check for working hibernation is enabled. The user might
-   * choose to disable it if we happen to be wrong.
-   *
-   * @returns bool true if we need to check if hibernation works.
-   */
-  setHibernateWorksCheckEnabled(enabled) {
-    let key = this.KEY_HIBERNATE_WORKS_CHECK;
-    if (this._setting.is_writable(key)) {
-      if (this._setting.set_boolean(key, enabled)) {
-        Gio.Settings.sync();
-      } else {
-        throw this._errorSet(key);
-      }
-    } else {
-      throw this._errorWritable(key);
+        const switchButton = new Gtk.Switch({
+            active: this._setting.get_boolean(key),
+        });
+
+        switchButton.connect("notify::active", (button) => {
+            this._setting.set_boolean(key, button.active);
+        });
+
+        hbox.append(switchButtonLabel);
+        hbox.append(switchButton);
+
+        return hbox;
     }
-  }
-  _errorWritable(key) {
-    return "The key '" + key + "' is not writable.";
-  }
-  _errorSet(key) {
-    return "Couldn't set the key '" + key + "'";
-  }
+
+    /**
+     * <p>Binds the given 'callback'-function to the "changed"-signal on the given
+     *  key.</p>
+     * <p>The 'callback'-function is passed an argument which holds the new
+     *  value of 'key'. The argument is of type "GLib.Variant". Given that the
+     *  receiver knows the internal type, use one of the get_XX()-methods to get
+     *  it's actual value.</p>
+     * @see http://www.roojs.com/seed/gir-1.2-gtk-3.0/gjs/GLib.Variant.html
+     * @param key the key to watch for changes.
+     * @param callback the callback-function to call.
+     */
+    bindKey(key, callback) {
+        // Validate:
+        if (key === undefined || key === null || typeof key !== "string") {
+            throw TypeError("The 'key' should be a string. Got: '" + key + "'");
+        }
+        if (
+            callback === undefined ||
+            callback === null ||
+            typeof callback !== "function"
+        ) {
+            throw TypeError(
+                "'callback' needs to be a function. Got: " + callback
+            );
+        }
+        // Bind:
+        this._setting.connect("changed::" + key, function (source, key) {
+            callback(source.get_value(key));
+        });
+    }
+
+    /**
+     * Get if check for working hibernation is enabled. The user might
+     * choose to disable it if we happen to be wrong.
+     *
+     * @returns bool true if we need to check if hibernation works.
+     */
+    getHibernateWorksCheckEnabled() {
+        return this._setting.get_boolean(this.KEY_HIBERNATE_WORKS_CHECK);
+    }
+
+    /**
+     * Get if the hibernate option is enabled.
+     *
+     * @returns bool true if we need to display the option.
+     */
+    getHibernateOptionEnabled() {
+        return this._setting.get_boolean(this.KEY_HIBERNATE_ENABLED);
+    }
+
+    /**
+     * Get if the hybrid sleep option is enabled.
+     *
+     * @returns bool true if we need to display the option.
+     */
+    getHybridSleepOptionEnabled() {
+        return this._setting.get_boolean(this.KEY_HYBRID_SLEEP_ENABLED);
+    }
+
+    /**
+     * Get if the hibernate confirmation option is enabled.
+     *
+     * @returns bool true if we need to display the option.
+     */
+    getHibernateConfirmationOptionEnabled() {
+        return this._setting.get_boolean(
+            this.KEY_HIBERNATE_CONFIRMATION_ENABLED
+        );
+    }
+
+    /**
+     * Set if check for working hibernation is enabled. The user might
+     * choose to disable it if we happen to be wrong.
+     *
+     * @returns bool true if we need to check if hibernation works.
+     */
+    setHibernateWorksCheckEnabled(enabled) {
+        let key = this.KEY_HIBERNATE_WORKS_CHECK;
+        if (this._setting.is_writable(key)) {
+            if (this._setting.set_boolean(key, enabled)) {
+                Gio.Settings.sync();
+            } else {
+                throw this._errorSet(key);
+            }
+        } else {
+            throw this._errorWritable(key);
+        }
+    }
+    _errorWritable(key) {
+        return "The key '" + key + "' is not writable.";
+    }
+    _errorSet(key) {
+        return "Couldn't set the key '" + key + "'";
+    }
 };
 
 // These "preferences" aren't user accessible so define
 // init() and buildPrefsWidget() to empty functions
 function init() {
-  ExtensionUtils.initTranslations("hibernate-status-button");
+    ExtensionUtils.initTranslations("hibernate-status-button");
 }
 function buildPrefsWidget() {
-  const prefs = getInstance();
-  return prefs.buildPrefsPanel();
+    const prefs = getInstance();
+    return prefs.buildPrefsPanel();
 }

--- a/schemas/org.gnome.shell.extensions.hibernate-status-button.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hibernate-status-button.gschema.xml
@@ -7,5 +7,11 @@
     <key type="b" name="hybridsleep-enabled">
       <default>true</default>
     </key>
+    <key type="b" name="hibernate-enabled">
+      <default>true</default>
+    </key>
+    <key type="b" name="hibernate-confirmation-enabled">
+      <default>true</default>
+    </key>
   </schema>
 </schemalist>

--- a/schemas/org.gnome.shell.extensions.hibernate-status-button.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.hibernate-status-button.gschema.xml
@@ -4,5 +4,8 @@
     <key type="b" name="hibernate-works-check">
       <default>true</default>
     </key>
+    <key type="b" name="hybridsleep-enabled">
+      <default>true</default>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
- Resolves #78 
- Resolves #2 

_(Sorry this one took a bit longer, life got in the way)_

I'm submitting this as a draft for right now as I think it might need a bit more cleaning up and checking, but would like to open this up for you (and possibly others) to help do this, and get some initial feedback.

![screenshot of the new, rather barren looking settings panel](https://user-images.githubusercontent.com/18850/184534395-3ba2d80f-ac3e-46bc-b72d-55659326d042.png)

I had to make some fundamental modifications to the code as this introduces an actual settings view -- and because I had to add this anyway, I figured I can just include #2 straight away too. With the implementation of making the hibernation confirmation dialog optional, I also went ahead and modified the actual hibernation button label to include the typical "..." to indicate there is a next action/step to the option, just like how "Restart..." is shown. I thought that minor detail would be nice to add.

I'd like to tackle the remaining open issue #23 as that'd actually be convenient for me too (I use suspend-then-hibernate on one of my devices that currently can't support full S3 sleep), but I feel like this might actually benefit from not being a separate option in the list, but instead replace the existing system suspend option. What do you think? Would a separate option be better, or should we look into the replace option?

Happy to take whatever feedback you can share, and I've enabled the allow edits checkbox, so please feel free to work along with me on this if there's anything you'd like to touch up.

Many thanks in advance!