### PR TITLE
Add Gnome 43 support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -135,14 +135,14 @@ class Extension {
     }
 
     _onHibernateClicked() {
-        this.systemMenu.menu.itemActivated();
+        this.systemMenu._systemItem.menu.itemActivated();
         this._dialog = new ConfirmDialog.ConfirmDialog(ConfirmDialog.HibernateDialogContent);
         this._dialog.connect('ConfirmedHibernate', () => this._loginManagerHibernate());
         this._dialog.open();
     }
 
     _onHybridSleepClicked() {
-        this.systemMenu.menu.itemActivated();
+        this.systemMenu._systemItem.menu.itemActivated();
         this._loginManagerHybridSleep();
     }
 
@@ -184,7 +184,7 @@ class Extension {
     enable() {
         this._checkRequirements();
         this._loginManager = LoginManager.getLoginManager();
-        this.systemMenu = Main.panel.statusArea['aggregateMenu']._system;
+        this.systemMenu = Main.panel.statusArea.quickSettings._system;
 
         this._hibernateMenuItem = new PopupMenu.PopupMenuItem(__('Hibernate'));
         this._hibernateMenuItemId = this._hibernateMenuItem.connect('activate', () => this._onHibernateClicked());
@@ -192,12 +192,12 @@ class Extension {
         this._hybridSleepMenuItem = new PopupMenu.PopupMenuItem(__('Hybrid Sleep'));
         this._hybridSleepMenuItemId = this._hybridSleepMenuItem.connect('activate', () => this._onHybridSleepClicked());
 
-        let afterSuspendPosition = this.systemMenu._sessionSubMenu.menu.numMenuItems - 5;
+        let afterSuspendPosition = this.systemMenu._systemItem.menu.numMenuItems - 5;
 
-        this.systemMenu._sessionSubMenu.menu.addMenuItem(this._hybridSleepMenuItem, afterSuspendPosition);
-        this.systemMenu._sessionSubMenu.menu.addMenuItem(this._hibernateMenuItem, afterSuspendPosition);
+        this.systemMenu._systemItem.menu.addMenuItem(this._hybridSleepMenuItem, afterSuspendPosition);
+        this.systemMenu._systemItem.menu.addMenuItem(this._hibernateMenuItem, afterSuspendPosition);
 
-        this._menuOpenStateChangedId = this.systemMenu.menu.connect('open-state-changed',
+        this._menuOpenStateChangedId = this.systemMenu._systemItem.menu.connect('open-state-changed',
             (menu, open) => {
                 if (!open)
                     return;
@@ -208,7 +208,7 @@ class Extension {
 
     disable() {
         if (this._menuOpenStateChangedId) {
-            this.systemMenu.menu.disconnect(this._menuOpenStateChangedId);
+            this.systemMenu._systemItem.menu.disconnect(this._menuOpenStateChangedId);
             this._menuOpenStateChangedId = 0;
         }
 

--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,7 @@
   "url": "https://github.com/arelange/gnome-shell-extension-hibernate-status",
   "description": "Adds a Hibernate button in Status menu. Using Alt modifier, you can also select Hybrid Sleep instead.",
   "shell-version": [
-    "40",
-    "41",
-    "42"
+    "43"
   ],
   "gettext-domain": "hibernate-status-button"
 }


### PR DESCRIPTION
Gnome 43 [removed `aggregateMenu` in version 43](https://gjs.guide/extensions/upgrading/gnome-shell-43.html#quick-settings). So, the extension no longer works on this version unless updated. This PR contains the proper changes to support Gnome 43.