### PR TITLE
Support system-wide setting schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ install-local: _build
 	cp -r ./_build/* $(INSTALLBASE)/$(INSTALLNAME)/
 ifeq ($(INSTALLTYPE),system)
 	# system-wide settings and locale files
-	# rm -r $(INSTALLBASE)/$(INSTALLNAME)/schemas
-	rm -f $(INSTALLBASE)/$(INSTALLNAME)/schemas/*gschema.xml
+	rm -r $(INSTALLBASE)/$(INSTALLNAME)/schemas
 	rm -r $(INSTALLBASE)/$(INSTALLNAME)/locale
 	mkdir -p $(SHARE_PREFIX)/glib-2.0/schemas $(SHARE_PREFIX)/locale
 	cp -r ./schemas/*gschema.* $(SHARE_PREFIX)/glib-2.0/schemas

--- a/prefs.js
+++ b/prefs.js
@@ -17,15 +17,25 @@ var Prefs = class Prefs {
         this.KEY_HIBERNATE_WORKS_CHECK = "hibernate-works-check";
         this._schemaName = "org.gnome.shell.extensions.hibernate-status-button";
 
-        let schemaDir = Me.dir.get_child('schemas').get_path();
+        // first try developer local schema
+        try {
+            let schemaDir = Me.dir.get_child('schemas').get_path();
 
-        let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
-            schemaDir, Gio.SettingsSchemaSource.get_default(), false
-        );
-        let schema = schemaSource.lookup(this._schemaName, false);
+            let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
+                schemaDir, Gio.SettingsSchemaSource.get_default(), false
+            );
+            let schema = schemaSource.lookup(this._schemaName, false);
+
+            this._setting = new Gio.Settings({
+                settings_schema: schema
+            });
+            return;
+        } catch (e) {
+            // now try system-wide one below
+        }
 
         this._setting = new Gio.Settings({
-            settings_schema: schema
+            schema_id: this._schemaName
         });
     }
     /**


### PR DESCRIPTION
When installing this extension properly, **utilizing and shipping the system-wide schema only** (_the glib-2.0 xml definition, letting the package manager handle the schema compilation_), it crashes with a FileError exception.

This resolves that issue.

Fixes #99