### PR TITLE
Close dialog after connect to the closed signal

### DIFF
--- a/confirmDialog.js
+++ b/confirmDialog.js
@@ -164,12 +164,12 @@ class ConfirmDialog extends ModalDialog.ModalDialog {
             let keys = dialog.confirmButtons[i].key;
             buttons.push({
                 action: () => {
-                    this.close();
                     let signalId = this.connect('closed',
                         () => {
                             this.disconnect(signalId);
                             this._confirm(signal);
                         });
+                    this.close();
                 },
                 label: label,
                 key: keys


### PR DESCRIPTION
The hibernate button is not working in Gnome 44 (tested on Fedora 38).
Probably because something changed in the GTK 4.0.

_Error message:_
`(...) ConfirmDialog (...) has been already disposed - impossible to connect to any signal on it.`

I fixed by [closing the dialog](https://github.com/arelange/gnome-shell-extension-hibernate-status/blob/d11284d8e8ef38aaf178963fb950b8ee347451a7/confirmDialog.js#L167) only [after connecting to the closed signal](https://github.com/arelange/gnome-shell-extension-hibernate-status/blob/d11284d8e8ef38aaf178963fb950b8ee347451a7/confirmDialog.js#L168) as the object property [destroyOnClose](https://github.com/arelange/gnome-shell-extension-hibernate-status/blob/d11284d8e8ef38aaf178963fb950b8ee347451a7/confirmDialog.js#L102) is set to true.

_Full error log:_
```
Jun 07 21:11:49 [machine] gnome-shell[2274]: have hibernate true
Jun 07 21:11:56 [machine] gnome-shell[2274]: Object .Gjs_hibernate-status_dromi_confirmDialog_ConfirmDialog (0x55b50e3615e0), has been already disposed — impossible to connect to any signal on it. This might be caused by the object having been destroyed from C code using something such as destroy(), dispose(), or remove() vfuncs.
Jun 07 21:11:56 [machine] gnome-shell[2274]: == Stack trace for context 0x55b509284130 ==
Jun 07 21:11:56 [machine] gnome-shell[2274]: #0   55b50eab7ee8 i   /home/[username]/.local/share/gnome-shell/extensions/hibernate-status@dromi/confirmDialog.js:168 (38c894f6c240 @ 43)
Jun 07 21:11:56 [machine] gnome-shell[2274]: #1   55b50eab7e68 i   resource:///org/gnome/shell/ui/dialog.js:130 (9f0a32c5060 @ 11)
```