### PR TITLE
Fix generation of pot file using make potfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 UUID = hibernate-status@dromi
 BASE_MODULES = extension.js metadata.json LICENSE README.md
 EXTRA_MODULES = prefs.js
-TOLOCALIZE =  confirmDialog.js prefs.js
+TOLOCALIZE =  extension.js prefs.js
 PO_FILES := $(wildcard ./locale/*/*/*.po)
 MO_FILES := $(PO_FILES:.po=.mo)
 
@@ -39,7 +39,7 @@ mergepo: potfile
 
 ./locale/hibernate-status-button.pot: $(TOLOCALIZE)
 	mkdir -p locale
-	xgettext -k --keyword=__ --keyword=N__ --add-comments='Translators:' -o locale/hibernate-status-button.pot --package-name "Hibernate Status Button" $(TOLOCALIZE)
+	xgettext --from=utf-8 -k --keyword=__ --keyword=N__ --add-comments='Translators:' -o locale/hibernate-status-button.pot --package-name "Hibernate Status Button" $(TOLOCALIZE)
 
 %.mo: %.po
 	msgfmt -c $< -o $@

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ If you are running Ubuntu, try putting
 into /etc/polkit-1/localauthority/10-vendor.d/com.ubuntu.desktop.pkla
 
 Otherwise check for similar settings for your distribution. Credit: https://github.com/arelange/gnome-shell-extension-hibernate-status/issues/41#issuecomment-565883599
+
+### Translation ###
+
+Translation can be done using gettext, one can generate the POT file using `make potfile` to generate a template in locale/hibernate-status-button.pot


### PR DESCRIPTION
Makefile seem to have been a bit outdated, so I updated the TOLOCALIZE to include the actual .js files, and set the source to UTF-8 to accomodate the "…" in the source (not sure those should be included that way, but for now, it is).

`make potfile` now works to build a template for translations, so I mentioned it in the README file for other translators.